### PR TITLE
Allow illuminate/contracts version 12.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     "require": {
         "php": "^8.2",
         "spatie/laravel-package-tools": "^1.15.0",
-        "illuminate/contracts": "^11.28"
+        "illuminate/contracts": "^11.28|^12.0"
     },
     "require-dev": {
         "filament/filament": "^4.0",


### PR DESCRIPTION
Support Laravel 12 in 4.x branch.